### PR TITLE
Update split_and_run_pbdagcon.path.sh

### DIFF
--- a/utility/split_and_run_pbdagcon.path.sh
+++ b/utility/split_and_run_pbdagcon.path.sh
@@ -53,6 +53,5 @@ ${split_dir}/${chunk}.mapped.m5"
 
 done
 
-cmd="cat ${split_dir}/*.consensus.fasta > ${split_dir}/final_assembly.fasta"
-echo=$cmd
-eval $cmd
+echo="merging consensus reads to ${split_dir}/final_assembly.fasta"
+for f in ${split_dir}/*.consensus.fasta; do cat "$f" >> ${split_dir}/final_assembly.fasta; done

--- a/utility/split_and_run_pbdagcon.path.sh
+++ b/utility/split_and_run_pbdagcon.path.sh
@@ -41,9 +41,7 @@ fi
 
 for file in $(find ${split_dir} -name "*.reads.fasta"); do
     chunk=`basename $file .reads.fasta`
-    cmd="blasr --nproc 64 ${split_dir}/${chunk}.reads.fasta 
-${split_dir}/${chunk}.fasta --bestn 1 -m 5 --minMatch 19 --out 
-${split_dir}/${chunk}.mapped.m5"
+    cmd="blasr --nproc 64 ${split_dir}/${chunk}.reads.fasta ${split_dir}/${chunk}.fasta --bestn 1 -m 5 --minMatch 19 --out ${split_dir}/${chunk}.mapped.m5"
     echo $cmd
     eval $cmd
 

--- a/utility/split_and_run_pbdagcon.path.sh
+++ b/utility/split_and_run_pbdagcon.path.sh
@@ -1,15 +1,14 @@
-#!/usr/bin/env bash
+#! /usr/bin/env bash
 
 if [ $# -eq 0 ]; then
- echo "
- ###
- # USAGE: split_and_run_pbdagcon.sh [BACKBONE_FASTA] [CONSENSUS_FASTA] [READS_FASTA] [OUTPUT_DIR][split_reads_by_backbone_version 1,2,3 - 3 by default]
- ###
- ## split_reads_by_backbone_version
- ## 1 = split_reads_by_backbone.py -- can cause "Too many files open" error. Good for small genomes and/or assemblies with few contigs.
- ## 2 = split_reads_by_backbone_readdict.py -- much faster, but requires enough memory to load all reads into memory. Will not cause "too many open files". Operation is a little different so order of reads.fastas can be different.
- ## 3 = split_reads_by_backbone_openclose.py -- a little slower than #1, but will not cause "too many open files". Will produce fastas in same order as #1. Make sure outdir is empty as it will append to existing files if they have the same name.
- ###
+ echo -e "USAGE: split_and_run_pbdagcon.sh [BACKBONE_FASTA] [CONSENSUS_FASTA] [READS_FASTA] [OUTPUT_DIR][split_reads_by_backbone_version 1,2,3 - 3 by default] \n
+ \t \t--split_reads_by_backbone_version-- \n
+ 1 = [split_reads_by_backbone.py] 
+ Can cause "Too many files open" error. Good for small genomes and/or assemblies with few contigs. \n
+ 2 = [split_reads_by_backbone_readdict.py] 
+ Much faster, but requires enough memory to load all reads into memory. Will not cause "too many open files". Operation is a little different so order of reads.fastas can be different. \n
+ 3 = [split_reads_by_backbone_openclose.py] 
+ A little slower than #1, but will not cause "too many open files". Will produce fastas in same order as #1. 
  "
  exit
 fi
@@ -25,10 +24,9 @@ else
  splitversion=3
 fi
 
-
-# if dir not there, make it; else clean the dir out
-if [ ! -d $split_dir ]; then mkdir $splitdir ; else  rm ${split_dir}/backbone-* ; fi
-
+# if directory present, remove it, otherwise create it
+rm -rf $split_dir
+mkdir -p $split_dir
 
 if [ $splitversion -eq 1 ]; then
  split_reads_by_backbone.py -b ${backbone_fasta} -o ${split_dir} -r ${reads_fasta} -c ${consensus_fasta} 
@@ -37,15 +35,15 @@ elif [ $splitversion -eq 2 ]; then
 elif [ $splitversion -eq 3 ]; then
  split_reads_by_backbone_openclose.py -b ${backbone_fasta} -o ${split_dir} -r ${reads_fasta} -c ${consensus_fasta} 
 else
- echo "splitversion (argument #6) needs to be 1, 2, or 3. If left blank, default is 1."
+ echo "splitversion (argument #6) needs to be 1, 2, or 3. If left blank, default is 3."
  exit
 fi
 
-
-for file in $(ls ${split_dir}/*.reads.fasta); do
+for file in $(find ${split_dir} -name "*.reads.fasta"); do
     chunk=`basename $file .reads.fasta`
-    #echo $chunk
-    cmd="blasr -nproc 64 ${split_dir}/${chunk}.reads.fasta ${split_dir}/${chunk}.fasta -bestn 1 -m 5 -minMatch 19 -out ${split_dir}/${chunk}.mapped.m5"
+    cmd="blasr --nproc 64 ${split_dir}/${chunk}.reads.fasta 
+${split_dir}/${chunk}.fasta --bestn 1 -m 5 --minMatch 19 --out 
+${split_dir}/${chunk}.mapped.m5"
     echo $cmd
     eval $cmd
 


### PR DESCRIPTION
replace `ls` with `find` to avoid "too many arguments" error
update mkdir/rm to avoid needless error logging
update usage